### PR TITLE
Fix non-functional analysis weights configuration

### DIFF
--- a/src/agents/crewai_agents.py
+++ b/src/agents/crewai_agents.py
@@ -10,6 +10,7 @@ from src.agents.output_models import (
     SignalSynthesisOutput,
     TechnicalAnalysisOutput,
 )
+from src.config import get_config
 from src.config.llm import initialize_llm_client
 from src.config.schemas import LLMConfig
 from src.utils.logging import get_logger
@@ -444,6 +445,12 @@ class CrewAITaskFactory:
         Returns:
             Configured Task object
         """
+        # Get weights from configuration
+        config = get_config()
+        w_tech = config.analysis.weight_technical
+        w_fund = config.analysis.weight_fundamental
+        w_sent = config.analysis.weight_sentiment
+
         return Task(
             description=(
                 f"Synthesize all analyses for {ticker} into a structured investment signal.\n"
@@ -452,8 +459,8 @@ class CrewAITaskFactory:
                 f"✓ DO: Synthesize the analysis data provided below\n"
                 f"✓ DO: Output ONLY a JSON object (no markdown, no text before or after)\n"
                 f"✓ DO: Extract scores from the analysis results provided\n"
-                f"✓ DO: Calculate final_score = (tech_score * 0.35) + "
-                f"(fundamental_score * 0.35) + (sentiment_score * 0.30)\n"
+                f"✓ DO: Calculate final_score = (tech_score * {w_tech}) + "
+                f"(fundamental_score * {w_fund}) + (sentiment_score * {w_sent})\n"
                 f"✗ DO NOT: Attempt to fetch or retrieve any data\n"
                 f"✗ DO NOT: Use any tools or make any function calls\n"
                 f"✗ DO NOT: Ask for additional data\n"
@@ -489,8 +496,8 @@ class CrewAITaskFactory:
                 f'    "fundamental": 0-100,\n'
                 f'    "sentiment": 0-100\n'
                 f"  }},\n"
-                f'  "final_score": 0-100 (weighted: fundamental 35%, technical '
-                f"35%, sentiment 30%),\n"
+                f'  "final_score": 0-100 (weighted: fundamental {w_fund * 100:.0f}%, technical '
+                f"{w_tech * 100:.0f}%, sentiment {w_sent * 100:.0f}%),\n"
                 f'  "recommendation": "strong_buy|buy|hold_bullish|hold|'
                 f'hold_bearish|sell|strong_sell",\n'
                 f'  "confidence": 0-100,\n'

--- a/src/agents/sentiment.py
+++ b/src/agents/sentiment.py
@@ -238,11 +238,12 @@ class SignalSynthesisAgent(BaseAgent):
             fundamental_score = context.get("fundamental_score", 50)
             sentiment_score = context.get("sentiment_score", 50)
 
-            # Weight the scores (configurable)
+            # Weight the scores (from configuration)
+            config = get_config()
             weights = {
-                "technical": 0.35,
-                "fundamental": 0.35,
-                "sentiment": 0.30,
+                "technical": config.analysis.weight_technical,
+                "fundamental": config.analysis.weight_fundamental,
+                "sentiment": config.analysis.weight_sentiment,
             }
 
             # Calculate final score


### PR DESCRIPTION
## Summary

Fixed the non-functional analysis weights configuration. Previously, the weights for fundamental, technical, and sentiment analysis were hardcoded to 0.35/0.35/0.30 in both rule-based and LLM modes, making the configuration option completely non-functional.

**Changes:**
- **Rule-based mode**: Modified `SignalSynthesisAgent` to read weights from config instead of using hardcoded values
- **LLM mode**: Updated CrewAI prompt template to dynamically inject config weights
- **Testing**: Added `test_custom_weights_respected()` to verify config weights are actually used in scoring

**Files modified:**
- `src/agents/sentiment.py` - Read weights from config in rule-based synthesis
- `src/agents/crewai_agents.py` - Inject dynamic weights into LLM prompts  
- `tests/analysis/test_signals.py` - Test to verify custom weights work correctly

## Test Plan

- [x] Unit test passes: `test_custom_weights_respected()` verifies custom weights (0.5/0.3/0.2)
- [x] All existing tests pass: 793 passed, 9 skipped
- [x] Code coverage maintained: 57% overall
- [x] Linting and formatting: All checks passed
- [x] Pre-commit hooks: All passed
- [x] LLM analysis verified: Successfully ran analysis with NVDA ticker
- [x] Manual verification: Config weights now properly affect final_score calculation

## Benefits

✅ Makes configuration actually work as documented  
✅ Users can customize scoring strategy without code changes  
✅ Removes DRY violation (single source of truth in config)  
✅ More flexible for different investment strategies  
✅ Cleaner codebase (no magic numbers)

Fixes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)